### PR TITLE
Fix profile's image URL

### DIFF
--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -8,7 +8,7 @@ devanshi:
   name: Devanshi Joshi
   title: Product Marketing Manager
   url: https://github.com/devanshidiaries
-  image_url: https://pbs.twimg.com/profile_images/1520928730230652928/00BaK5xn_400x400.jpg
+  image_url: https://github.com/devanshidiaries.png
 
 gwyn:
   name: Gwyneth Peña-Siguenza


### PR DESCRIPTION
Devanshi Joshi's profile image was hot-linked from Twitter. I look up her Github's profile image and fix the link accodringly.